### PR TITLE
Always log parseable commands

### DIFF
--- a/txWorker.go
+++ b/txWorker.go
@@ -20,8 +20,8 @@ func processTxs(unprocessedTxs <-chan string) {
 	// next transaction is grabbed.
 	defer catchAbortedTx()
 	cmd := parseCommand(<-unprocessedTxs)
-	cmd.Execute()
 	go sendToAuditLog(cmd)
+	cmd.Execute()
 }
 
 func abortTx(msg string) {


### PR DESCRIPTION
Commands that are aborted because of invalid preconditions still need an entry in the audit log. The logging go routine executes independently of aborts / panics thrown in `Execute()`

#### Runtime logs
10 QUOTEs are pushed into the `pendingtx` Redis list. `commands_quotes.go` is altered to `abortTx()` as soon as `Execute()` starts.
```
$ go run *.go -l NOTICE -n 1
14:57:49.510 ▶    ERROR 001  [x] Aborted transaction: NO QUOTE FOR YOU: BFD txWorker.go:39
14:57:49.510 ▶    ERROR 002  [x] Aborted transaction: NO QUOTE FOR YOU: ODC txWorker.go:39
14:57:49.511 ▶    ERROR 003  [x] Aborted transaction: NO QUOTE FOR YOU: WYM txWorker.go:39
14:57:49.511 ▶   NOTICE 004 Sent audit log: [7] QUOTE commands.go:98
14:57:49.512 ▶    ERROR 005  [x] Aborted transaction: NO QUOTE FOR YOU: MHC txWorker.go:39
14:57:49.512 ▶    ERROR 006  [x] Aborted transaction: NO QUOTE FOR YOU: BFD txWorker.go:39
14:57:49.512 ▶   NOTICE 007 Sent audit log: [9] QUOTE commands.go:98
14:57:49.513 ▶    ERROR 008  [x] Aborted transaction: NO QUOTE FOR YOU: MHC txWorker.go:39
14:57:49.513 ▶    ERROR 009  [x] Aborted transaction: NO QUOTE FOR YOU: GPR txWorker.go:39
14:57:49.513 ▶   NOTICE 010 Sent audit log: [14] QUOTE commands.go:98
14:57:49.514 ▶    ERROR 011  [x] Aborted transaction: NO QUOTE FOR YOU: BFD txWorker.go:39
14:57:49.514 ▶   NOTICE 012 Sent audit log: [48] QUOTE commands.go:98
14:57:49.516 ▶    ERROR 013  [x] Aborted transaction: NO QUOTE FOR YOU: MHC txWorker.go:39
14:57:49.516 ▶   NOTICE 014 Sent audit log: [52] QUOTE commands.go:98
14:57:49.518 ▶    ERROR 015  [x] Aborted transaction: NO QUOTE FOR YOU: EXV txWorker.go:39
14:57:49.518 ▶   NOTICE 016 Sent audit log: [61] QUOTE commands.go:98
14:57:49.518 ▶   NOTICE 017 Sent audit log: [54] QUOTE commands.go:98
14:57:49.518 ▶   NOTICE 018 Sent audit log: [83] QUOTE commands.go:98
14:57:49.519 ▶   NOTICE 019 Sent audit log: [84] QUOTE commands.go:98
14:57:49.520 ▶   NOTICE 020 Sent audit log: [85] QUOTE commands.go:98
```
Verified by inspection that messages made it into the `audit_log` queue of RMQ.