### PR TITLE
Add gofmt check to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - go build .
 
 script:
-  - ./scripts/pre-push
+  - ./githooks/pre-push
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - go build .
 
 script:
-  - gometalinter --config=.gometalinterrc ./...
+  - ./script/pre-push
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - go build .
 
 script:
-  - ./script/pre-push
+  - ./scripts/pre-push
 
 notifications:
   email: false

--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -9,3 +9,13 @@ if [ $? -ne 0 ]; then
 else
   echo "✔ Linter passed"
 fi
+
+# Check for files with formatting different from gofmt's
+gofmt -l .
+
+if [ $? -ne 0 ]; then
+  echo "✗ gofmt failed. Branch not pushed to remote."
+  exit 1
+else
+  echo "✔ gofmt passed"
+fi


### PR DESCRIPTION
Prevents us from introducing noise into commits. Atom, VSCode both run `gofmt` on save.