### PR TITLE
Only wait for fresh quotes if QuoteRequest forces freshness

### DIFF
--- a/quotecache.go
+++ b/quotecache.go
@@ -167,12 +167,20 @@ func watchForQuoteUpdate(qr types.QuoteRequest, freshQuotes chan<- types.Quote, 
 	)
 	failOnError(err, "Failed to declare a queue")
 
+	var freshnessFilter string
+	if qr.AllowCache {
+		// Catch fresh and cached
+		freshnessFilter = ".*"
+	} else {
+		freshnessFilter = ".fresh"
+	}
+
 	err = ch.QueueBind(
-		q.Name,            // name
-		qr.Stock+".fresh", // routing key
-		quoteBroadcastEx,  // exchange
-		false,             // no-wait
-		nil,               // args
+		q.Name, // name
+		qr.Stock+freshnessFilter, // routing key
+		quoteBroadcastEx,         // exchange
+		false,                    // no-wait
+		nil,                      // args
 	)
 	failOnError(err, "Failed to bind a queue")
 


### PR DESCRIPTION
See #8 for the issue this resolves. Now we only block while waiting for a `.fresh` quote if we know the quote manager *will* return a `.fresh` quote.