### PR TITLE
Use a single RMQ channel for sending to audit

### DIFF
--- a/txWorker.go
+++ b/txWorker.go
@@ -37,8 +37,13 @@ func processTxs(unprocessedTxs <-chan string) {
 	// Control returns to txWorker() where the select{} repeats and the
 	// next transaction is grabbed.
 	defer catchAbortedTx()
+
 	cmd := parseCommand(<-unprocessedTxs)
-	loggableCmds <- cmd
+
+	if !*noAudit {
+		loggableCmds <- cmd
+	}
+
 	cmd.Execute()
 }
 


### PR DESCRIPTION
I suspect that the overhead associated with creating / closing a channel for each logged command is what caused the program to fail for >45 users. 

I've solved the problem by collecting loggable commands in a go channel and re-using a single RMQ channel to publish the message. Problems haven't appeared in the lab since I made this change!

#### Style note
I'm mixing procedures for sharing channels between functions. In some I pass it as a parameter, in others I reference a global. I'm preferring the global pattern because I don't have to pass the channel down to its various consumers / producers. This makes refactoring easier. Downside is that it's not always obvious where the channel comes from. I think I can mitigate the ambiguous origin in this case because the channel isn't used outside of this file. 