### PR TITLE
Child redis key pieces start with :

### DIFF
--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -10,7 +10,7 @@ redis:
   max idle connections: 5
   max active connections: 0 # 0 = unlimited
   idle timeout: 30 # seconds
-  key prefix: "worker:"
+  key prefix: "worker"
 
 # This defines the retention policy for quotes in the cache.
 # Each quote is valid for 60s from the timestamp returned from the

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -10,7 +10,7 @@ redis:
   max idle connections: 5
   max active connections: 0
   idle timeout: 30
-  key prefix: "worker:"
+  key prefix: "worker"
 
 quote policy:
   base ttl: 59

--- a/incomingTxWatcher.go
+++ b/incomingTxWatcher.go
@@ -34,7 +34,6 @@ func handler(w http.ResponseWriter, r *http.Request) {
 func incomingTxWatcher() {
 	conn = redisPool.Get()
 	port := fmt.Sprintf(":%d", config.Redis.Port+*workerNum)
-	fmt.Printf("Started watching on port %s\n", port)
 	consoleLog.Debugf("Started watching on port %s\n", port)
 	http.HandleFunc("/", handler)
 	http.ListenAndServe(port, nil)

--- a/main.go
+++ b/main.go
@@ -65,8 +65,8 @@ func main() {
 	kingpin.Parse()
 	initConsoleLogging()
 	loadConfig()
-	redisBaseKey = fmt.Sprintf("%s%d:", config.Redis.KeyPrefix, *workerNum)
-	pendingTxKey = fmt.Sprintf("%spendingTx", redisBaseKey)
+	redisBaseKey = fmt.Sprintf("%s%d", config.Redis.KeyPrefix, *workerNum)
+	pendingTxKey = fmt.Sprintf("%s:pendingTx", redisBaseKey)
 	// Connect to external services
 	initRMQ()
 	defer rmqConn.Close()

--- a/main.go
+++ b/main.go
@@ -65,8 +65,8 @@ func main() {
 	kingpin.Parse()
 	initConsoleLogging()
 	loadConfig()
-	redisBaseKey = fmt.Sprintf("%s%d", config.Redis.KeyPrefix, *workerNum)
-	pendingTxKey = fmt.Sprintf("%s:pendingTx", redisBaseKey)
+	redisBaseKey = fmt.Sprintf("%s:%d", config.Redis.KeyPrefix, *workerNum)
+	pendingTxKey = redisBaseKey + ":pendingTx"
 	// Connect to external services
 	initRMQ()
 	defer rmqConn.Close()

--- a/quotecache.go
+++ b/quotecache.go
@@ -46,7 +46,7 @@ func catchQuoteBroadcasts() {
 	defer ch.Close()
 
 	q, err := ch.QueueDeclare(
-		redisBaseKey+"updater", // name
+		redisBaseKey+":updater", // name
 		true,  // durable
 		true,  // delete when unused
 		false, // exclusive
@@ -115,7 +115,7 @@ func cacheQuote(q types.Quote) {
 }
 
 func getQuoteKey(stock string) string {
-	return redisBaseKey + "quotes:" + stock
+	return redisBaseKey + ":quotes:" + stock
 }
 
 // getQuote checks local redis for a quote


### PR DESCRIPTION
There shouldn't be separate logic for composing the base key with other key pieces. `base + branch1 + branch2` should work the same as `base + branch2 + branch1`. This is a pain in the ass when it's not clear where the `:` appear in `branch1` and `branch2`.

All key pieces will start with `:`, except the base key.

Resolves: #11