### PR TITLE
Add UserID to command

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -8,6 +8,7 @@ import (
 type command interface {
 	Execute()
 	Name() string
+	GetUserID() string
 	ToAuditEntry() string
 }
 

--- a/commands_add.go
+++ b/commands_add.go
@@ -36,6 +36,10 @@ func (a addCmd) Name() string {
 	return fmt.Sprintf("[%d] ADD", a.id)
 }
 
+func (a addCmd) GetUserID() string {
+	return a.userID
+}
+
 func (a addCmd) ToAuditEntry() string {
 	return fmt.Sprintf(`
 	<userCommand>

--- a/commands_buy.go
+++ b/commands_buy.go
@@ -38,6 +38,10 @@ func (b buyCmd) Name() string {
 	return fmt.Sprintf("[%d] BUY", b.id)
 }
 
+func (b buyCmd) GetUserID() string {
+	return b.userID
+}
+
 func (b buyCmd) ToAuditEntry() string {
 	return fmt.Sprintf(`
 	<userCommand>

--- a/commands_cancelBuy.go
+++ b/commands_cancelBuy.go
@@ -29,6 +29,10 @@ func (cb cancelBuyCmd) Name() string {
 	return fmt.Sprintf("[%d] CANCEL_BUY", cb.id)
 }
 
+func (cb cancelBuyCmd) GetUserID() string {
+	return cb.userID
+}
+
 func (cb cancelBuyCmd) ToAuditEntry() string {
 	return fmt.Sprintf(`
 	<userCommand>

--- a/commands_cancelSell.go
+++ b/commands_cancelSell.go
@@ -29,6 +29,10 @@ func (cs cancelSellCmd) Name() string {
 	return fmt.Sprintf("[%d] CANCEL_SELL", cs.id)
 }
 
+func (cs cancelSellCmd) GetUserID() string {
+	return cs.userID
+}
+
 func (cs cancelSellCmd) ToAuditEntry() string {
 	return fmt.Sprintf(`
 	<userCommand>

--- a/commands_cancelSetBuy.go
+++ b/commands_cancelSetBuy.go
@@ -31,6 +31,10 @@ func (csb cancelSetBuyCmd) Name() string {
 	return fmt.Sprintf("[%d] CANCEL_SET_BUY", csb.id)
 }
 
+func (csb cancelSetBuyCmd) GetUserID() string {
+	return csb.userID
+}
+
 func (csb cancelSetBuyCmd) ToAuditEntry() string {
 	return fmt.Sprintf(`
 	<userCommand>

--- a/commands_cancelSetSell.go
+++ b/commands_cancelSetSell.go
@@ -31,6 +31,10 @@ func (css cancelSetSellCmd) Name() string {
 	return fmt.Sprintf("[%d] CANCEL_SET_SELL", css.id)
 }
 
+func (css cancelSetSellCmd) GetUserID() string {
+	return css.userID
+}
+
 func (css cancelSetSellCmd) ToAuditEntry() string {
 	return fmt.Sprintf(`
 	<userCommand>

--- a/commands_commitBuy.go
+++ b/commands_commitBuy.go
@@ -29,6 +29,10 @@ func (cb commitBuyCmd) Name() string {
 	return fmt.Sprintf("[%d] COMMIT_BUY", cb.id)
 }
 
+func (cb commitBuyCmd) GetUserID() string {
+	return cb.userID
+}
+
 func (cb commitBuyCmd) ToAuditEntry() string {
 	return fmt.Sprintf(`
 	<userCommand>

--- a/commands_commitSell.go
+++ b/commands_commitSell.go
@@ -29,6 +29,10 @@ func (cs commitSellCmd) Name() string {
 	return fmt.Sprintf("[%d] COMMIT_SELL", cs.id)
 }
 
+func (cs commitSellCmd) GetUserID() string {
+	return cs.userID
+}
+
 func (cs commitSellCmd) ToAuditEntry() string {
 	return fmt.Sprintf(`
 	<userCommand>

--- a/commands_displaySummary.go
+++ b/commands_displaySummary.go
@@ -29,6 +29,10 @@ func (ds displaySummaryCmd) Name() string {
 	return fmt.Sprintf("[%d] DISPLAY_SUMMARY", ds.id)
 }
 
+func (ds displaySummaryCmd) GetUserID() string {
+	return ds.userID
+}
+
 func (ds displaySummaryCmd) ToAuditEntry() string {
 	return fmt.Sprintf(`
 	<userCommand>

--- a/commands_dumplog.go
+++ b/commands_dumplog.go
@@ -40,17 +40,28 @@ func (dl dumplogCmd) Name() string {
 	return fmt.Sprintf("[%d] DUMPLOG", dl.id)
 }
 
+func (dl dumplogCmd) GetUserID() string {
+	return dl.userID
+}
+
 func (dl dumplogCmd) ToAuditEntry() string {
+	// Workload file validator will fail if it sees the injected "admin" account
+	// in the workload file. We'll make it disappear here but carry it through
+	// the rest of the system.
+	var userNameField string
+	if dl.userID != "admin" {
+		userNameField = fmt.Sprintf("\n\t\t<username>%s</username>", dl.userID)
+	}
+
 	return fmt.Sprintf(`
 	<userCommand>
 		<timestamp>%d</timestamp>
 		<server>%s</server>
 		<transactionNum>%d</transactionNum>
-		<command>DUMPLOG</command>
-		<username>%s</username>
+		<command>DUMPLOG</command>%s
 		<filename>%s</filename>
 	</userCommand>`,
-		time.Now().UnixNano()/1e6, redisBaseKey, dl.id, dl.userID, dl.filename,
+		time.Now().UnixNano()/1e6, redisBaseKey, dl.id, userNameField, dl.filename,
 	)
 }
 

--- a/commands_quote.go
+++ b/commands_quote.go
@@ -33,6 +33,10 @@ func (q quoteCmd) Name() string {
 	return fmt.Sprintf("[%d] QUOTE", q.id)
 }
 
+func (q quoteCmd) GetUserID() string {
+	return q.userID
+}
+
 func (q quoteCmd) ToAuditEntry() string {
 	return fmt.Sprintf(`
 	<userCommand>

--- a/commands_sell.go
+++ b/commands_sell.go
@@ -38,6 +38,10 @@ func (s sellCmd) Name() string {
 	return fmt.Sprintf("[%d] SELL", s.id)
 }
 
+func (s sellCmd) GetUserID() string {
+	return s.userID
+}
+
 func (s sellCmd) ToAuditEntry() string {
 	return fmt.Sprintf(`
 	<userCommand>

--- a/commands_setBuyAmount.go
+++ b/commands_setBuyAmount.go
@@ -38,6 +38,10 @@ func (sba setBuyAmountCmd) Name() string {
 	return fmt.Sprintf("[%d] SET_BUY_AMOUNT", sba.id)
 }
 
+func (sba setBuyAmountCmd) GetUserID() string {
+	return sba.userID
+}
+
 func (sba setBuyAmountCmd) ToAuditEntry() string {
 	return fmt.Sprintf(`
 	<userCommand>

--- a/commands_setBuyTrigger.go
+++ b/commands_setBuyTrigger.go
@@ -38,6 +38,10 @@ func (sbt setBuyTriggerCmd) Name() string {
 	return fmt.Sprintf("[%d] SET_BUY_TRIGGER", sbt.id)
 }
 
+func (sbt setBuyTriggerCmd) GetUserID() string {
+	return sbt.userID
+}
+
 func (sbt setBuyTriggerCmd) ToAuditEntry() string {
 	return fmt.Sprintf(`
 	<userCommand>

--- a/commands_setSellAmount.go
+++ b/commands_setSellAmount.go
@@ -38,6 +38,10 @@ func (ssa setSellAmountCmd) Name() string {
 	return fmt.Sprintf("[%d] SET_SELL_AMOUNT", ssa.id)
 }
 
+func (ssa setSellAmountCmd) GetUserID() string {
+	return ssa.userID
+}
+
 func (ssa setSellAmountCmd) ToAuditEntry() string {
 	return fmt.Sprintf(`
 	<userCommand>

--- a/commands_setSellTrigger.go
+++ b/commands_setSellTrigger.go
@@ -38,6 +38,10 @@ func (sst setSellTriggerCmd) Name() string {
 	return fmt.Sprintf("[%d] SET_SELL_TRIGGER", sst.id)
 }
 
+func (sst setSellTriggerCmd) GetUserID() string {
+	return sst.userID
+}
+
 func (sst setSellTriggerCmd) ToAuditEntry() string {
 	return fmt.Sprintf(`
 	<userCommand>

--- a/txWorker.go
+++ b/txWorker.go
@@ -83,6 +83,7 @@ func sendCmdToAudit() {
 			header := amqp.Table{
 				"name":      cmd.Name(),
 				"serviceID": redisBaseKey,
+				"userID":    cmd.GetUserID(),
 			}
 
 			err := logChannel.Publish(


### PR DESCRIPTION
This makes it easier to work with the logging refactor I have underway.

I'm pushing to merge this now because it also fixes the self-inflicted error of introducing the `admin` account to the audit log. Tx will still be labeled `admin` through the system for tracking, security, etc. but this behavior won't manifest in the generated audit log. Audit logs don't validate if they have "extra" accounts.