### PR TITLE
Send AuditEvents instead of xml logs

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -3,13 +3,14 @@ package main
 import (
 	"fmt"
 	"strings"
+
+	types "github.com/distributeddesigns/shared_types"
 )
 
 type command interface {
 	Execute()
 	Name() string
-	GetUserID() string
-	ToAuditEntry() string
+	ToAuditEvent() types.AuditEvent
 }
 
 func parseCommand(s string) command {

--- a/commands_add.go
+++ b/commands_add.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/distributeddesigns/currency"
+	types "github.com/distributeddesigns/shared_types"
 )
 
 type addCmd struct {
@@ -36,12 +37,8 @@ func (a addCmd) Name() string {
 	return fmt.Sprintf("[%d] ADD", a.id)
 }
 
-func (a addCmd) GetUserID() string {
-	return a.userID
-}
-
-func (a addCmd) ToAuditEntry() string {
-	return fmt.Sprintf(`
+func (a addCmd) ToAuditEvent() types.AuditEvent {
+	xmlElement := fmt.Sprintf(`
 	<userCommand>
 		<timestamp>%d</timestamp>
 		<server>%s</server>
@@ -52,6 +49,13 @@ func (a addCmd) ToAuditEntry() string {
 	</userCommand>`,
 		time.Now().UnixNano()/1e6, redisBaseKey, a.id, a.userID, a.amount.ToFloat(),
 	)
+
+	return types.AuditEvent{
+		UserID:    a.userID,
+		ID:        a.id,
+		EventType: "command",
+		Content:   xmlElement,
+	}
 }
 
 func (a addCmd) Execute() {

--- a/commands_buy.go
+++ b/commands_buy.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/distributeddesigns/currency"
+	types "github.com/distributeddesigns/shared_types"
 )
 
 type buyCmd struct {
@@ -38,12 +39,8 @@ func (b buyCmd) Name() string {
 	return fmt.Sprintf("[%d] BUY", b.id)
 }
 
-func (b buyCmd) GetUserID() string {
-	return b.userID
-}
-
-func (b buyCmd) ToAuditEntry() string {
-	return fmt.Sprintf(`
+func (b buyCmd) ToAuditEvent() types.AuditEvent {
+	xmlElement := fmt.Sprintf(`
 	<userCommand>
 		<timestamp>%d</timestamp>
 		<server>%s</server>
@@ -55,6 +52,13 @@ func (b buyCmd) ToAuditEntry() string {
 	</userCommand>`,
 		time.Now().UnixNano()/1e6, redisBaseKey, b.id, b.userID, b.stock, b.amount.ToFloat(),
 	)
+
+	return types.AuditEvent{
+		UserID:    b.userID,
+		ID:        b.id,
+		EventType: "command",
+		Content:   xmlElement,
+	}
 }
 
 func (b buyCmd) Execute() {

--- a/commands_cancelBuy.go
+++ b/commands_cancelBuy.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 	"time"
+
+	types "github.com/distributeddesigns/shared_types"
 )
 
 type cancelBuyCmd struct {
@@ -29,12 +31,8 @@ func (cb cancelBuyCmd) Name() string {
 	return fmt.Sprintf("[%d] CANCEL_BUY", cb.id)
 }
 
-func (cb cancelBuyCmd) GetUserID() string {
-	return cb.userID
-}
-
-func (cb cancelBuyCmd) ToAuditEntry() string {
-	return fmt.Sprintf(`
+func (cb cancelBuyCmd) ToAuditEvent() types.AuditEvent {
+	xmlElement := fmt.Sprintf(`
 	<userCommand>
 		<timestamp>%d</timestamp>
 		<server>%s</server>
@@ -44,6 +42,13 @@ func (cb cancelBuyCmd) ToAuditEntry() string {
 	</userCommand>`,
 		time.Now().UnixNano()/1e6, redisBaseKey, cb.id, cb.userID,
 	)
+
+	return types.AuditEvent{
+		UserID:    cb.userID,
+		ID:        cb.id,
+		EventType: "command",
+		Content:   xmlElement,
+	}
 }
 
 func (cb cancelBuyCmd) Execute() {

--- a/commands_cancelSell.go
+++ b/commands_cancelSell.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 	"time"
+
+	types "github.com/distributeddesigns/shared_types"
 )
 
 type cancelSellCmd struct {
@@ -29,12 +31,8 @@ func (cs cancelSellCmd) Name() string {
 	return fmt.Sprintf("[%d] CANCEL_SELL", cs.id)
 }
 
-func (cs cancelSellCmd) GetUserID() string {
-	return cs.userID
-}
-
-func (cs cancelSellCmd) ToAuditEntry() string {
-	return fmt.Sprintf(`
+func (cs cancelSellCmd) ToAuditEvent() types.AuditEvent {
+	xmlElement := fmt.Sprintf(`
 	<userCommand>
 		<timestamp>%d</timestamp>
 		<server>%s</server>
@@ -44,6 +42,13 @@ func (cs cancelSellCmd) ToAuditEntry() string {
 	</userCommand>`,
 		time.Now().UnixNano()/1e6, redisBaseKey, cs.id, cs.userID,
 	)
+
+	return types.AuditEvent{
+		UserID:    cs.userID,
+		ID:        cs.id,
+		EventType: "command",
+		Content:   xmlElement,
+	}
 }
 
 func (cs cancelSellCmd) Execute() {

--- a/commands_cancelSetBuy.go
+++ b/commands_cancelSetBuy.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 	"time"
+
+	types "github.com/distributeddesigns/shared_types"
 )
 
 type cancelSetBuyCmd struct {
@@ -31,12 +33,8 @@ func (csb cancelSetBuyCmd) Name() string {
 	return fmt.Sprintf("[%d] CANCEL_SET_BUY", csb.id)
 }
 
-func (csb cancelSetBuyCmd) GetUserID() string {
-	return csb.userID
-}
-
-func (csb cancelSetBuyCmd) ToAuditEntry() string {
-	return fmt.Sprintf(`
+func (csb cancelSetBuyCmd) ToAuditEvent() types.AuditEvent {
+	xmlElement := fmt.Sprintf(`
 	<userCommand>
 		<timestamp>%d</timestamp>
 		<server>%s</server>
@@ -47,6 +45,13 @@ func (csb cancelSetBuyCmd) ToAuditEntry() string {
 	</userCommand>`,
 		time.Now().UnixNano()/1e6, redisBaseKey, csb.id, csb.userID, csb.stock,
 	)
+
+	return types.AuditEvent{
+		UserID:    csb.userID,
+		ID:        csb.id,
+		EventType: "command",
+		Content:   xmlElement,
+	}
 }
 
 func (csb cancelSetBuyCmd) Execute() {

--- a/commands_cancelSetSell.go
+++ b/commands_cancelSetSell.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 	"time"
+
+	types "github.com/distributeddesigns/shared_types"
 )
 
 type cancelSetSellCmd struct {
@@ -31,12 +33,8 @@ func (css cancelSetSellCmd) Name() string {
 	return fmt.Sprintf("[%d] CANCEL_SET_SELL", css.id)
 }
 
-func (css cancelSetSellCmd) GetUserID() string {
-	return css.userID
-}
-
-func (css cancelSetSellCmd) ToAuditEntry() string {
-	return fmt.Sprintf(`
+func (css cancelSetSellCmd) ToAuditEvent() types.AuditEvent {
+	xmlElement := fmt.Sprintf(`
 	<userCommand>
 		<timestamp>%d</timestamp>
 		<server>%s</server>
@@ -47,6 +45,13 @@ func (css cancelSetSellCmd) ToAuditEntry() string {
 	</userCommand>`,
 		time.Now().UnixNano()/1e6, redisBaseKey, css.id, css.userID, css.stock,
 	)
+
+	return types.AuditEvent{
+		UserID:    css.userID,
+		ID:        css.id,
+		EventType: "command",
+		Content:   xmlElement,
+	}
 }
 
 func (css cancelSetSellCmd) Execute() {

--- a/commands_commitBuy.go
+++ b/commands_commitBuy.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 	"time"
+
+	types "github.com/distributeddesigns/shared_types"
 )
 
 type commitBuyCmd struct {
@@ -29,12 +31,8 @@ func (cb commitBuyCmd) Name() string {
 	return fmt.Sprintf("[%d] COMMIT_BUY", cb.id)
 }
 
-func (cb commitBuyCmd) GetUserID() string {
-	return cb.userID
-}
-
-func (cb commitBuyCmd) ToAuditEntry() string {
-	return fmt.Sprintf(`
+func (cb commitBuyCmd) ToAuditEvent() types.AuditEvent {
+	xmlElement := fmt.Sprintf(`
 	<userCommand>
 		<timestamp>%d</timestamp>
 		<server>%s</server>
@@ -44,6 +42,13 @@ func (cb commitBuyCmd) ToAuditEntry() string {
 	</userCommand>`,
 		time.Now().UnixNano()/1e6, redisBaseKey, cb.id, cb.userID,
 	)
+
+	return types.AuditEvent{
+		UserID:    cb.userID,
+		ID:        cb.id,
+		EventType: "command",
+		Content:   xmlElement,
+	}
 }
 
 func (cb commitBuyCmd) Execute() {

--- a/commands_commitSell.go
+++ b/commands_commitSell.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 	"time"
+
+	types "github.com/distributeddesigns/shared_types"
 )
 
 type commitSellCmd struct {
@@ -29,12 +31,8 @@ func (cs commitSellCmd) Name() string {
 	return fmt.Sprintf("[%d] COMMIT_SELL", cs.id)
 }
 
-func (cs commitSellCmd) GetUserID() string {
-	return cs.userID
-}
-
-func (cs commitSellCmd) ToAuditEntry() string {
-	return fmt.Sprintf(`
+func (cs commitSellCmd) ToAuditEvent() types.AuditEvent {
+	xmlElement := fmt.Sprintf(`
 	<userCommand>
 		<timestamp>%d</timestamp>
 		<server>%s</server>
@@ -44,6 +42,13 @@ func (cs commitSellCmd) ToAuditEntry() string {
 	</userCommand>`,
 		time.Now().UnixNano()/1e6, redisBaseKey, cs.id, cs.userID,
 	)
+
+	return types.AuditEvent{
+		UserID:    cs.userID,
+		ID:        cs.id,
+		EventType: "command",
+		Content:   xmlElement,
+	}
 }
 
 func (cs commitSellCmd) Execute() {

--- a/commands_displaySummary.go
+++ b/commands_displaySummary.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 	"time"
+
+	types "github.com/distributeddesigns/shared_types"
 )
 
 type displaySummaryCmd struct {
@@ -29,12 +31,8 @@ func (ds displaySummaryCmd) Name() string {
 	return fmt.Sprintf("[%d] DISPLAY_SUMMARY", ds.id)
 }
 
-func (ds displaySummaryCmd) GetUserID() string {
-	return ds.userID
-}
-
-func (ds displaySummaryCmd) ToAuditEntry() string {
-	return fmt.Sprintf(`
+func (ds displaySummaryCmd) ToAuditEvent() types.AuditEvent {
+	xmlElement := fmt.Sprintf(`
 	<userCommand>
 		<timestamp>%d</timestamp>
 		<server>%s</server>
@@ -44,6 +42,13 @@ func (ds displaySummaryCmd) ToAuditEntry() string {
 	</userCommand>`,
 		time.Now().UnixNano()/1e6, redisBaseKey, ds.id, ds.userID,
 	)
+
+	return types.AuditEvent{
+		UserID:    ds.userID,
+		ID:        ds.id,
+		EventType: "command",
+		Content:   xmlElement,
+	}
 }
 
 func (ds displaySummaryCmd) Execute() {

--- a/commands_quote.go
+++ b/commands_quote.go
@@ -33,12 +33,8 @@ func (q quoteCmd) Name() string {
 	return fmt.Sprintf("[%d] QUOTE", q.id)
 }
 
-func (q quoteCmd) GetUserID() string {
-	return q.userID
-}
-
-func (q quoteCmd) ToAuditEntry() string {
-	return fmt.Sprintf(`
+func (q quoteCmd) ToAuditEvent() types.AuditEvent {
+	xmlElement := fmt.Sprintf(`
 	<userCommand>
 		<timestamp>%d</timestamp>
 		<server>%s</server>
@@ -49,6 +45,13 @@ func (q quoteCmd) ToAuditEntry() string {
 	</userCommand>`,
 		time.Now().UnixNano()/1e6, redisBaseKey, q.id, q.userID, q.stock,
 	)
+
+	return types.AuditEvent{
+		UserID:    q.userID,
+		ID:        q.id,
+		EventType: "command",
+		Content:   xmlElement,
+	}
 }
 
 func (q quoteCmd) Execute() {

--- a/commands_sell.go
+++ b/commands_sell.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/distributeddesigns/currency"
+	types "github.com/distributeddesigns/shared_types"
 )
 
 type sellCmd struct {
@@ -38,12 +39,8 @@ func (s sellCmd) Name() string {
 	return fmt.Sprintf("[%d] SELL", s.id)
 }
 
-func (s sellCmd) GetUserID() string {
-	return s.userID
-}
-
-func (s sellCmd) ToAuditEntry() string {
-	return fmt.Sprintf(`
+func (s sellCmd) ToAuditEvent() types.AuditEvent {
+	xmlElement := fmt.Sprintf(`
 	<userCommand>
 		<timestamp>%d</timestamp>
 		<server>%s</server>
@@ -56,6 +53,13 @@ func (s sellCmd) ToAuditEntry() string {
 		time.Now().UnixNano()/1e6, redisBaseKey, s.id, s.userID,
 		s.stock, s.amount.ToFloat(),
 	)
+
+	return types.AuditEvent{
+		UserID:    s.userID,
+		ID:        s.id,
+		EventType: "command",
+		Content:   xmlElement,
+	}
 }
 
 func (s sellCmd) Execute() {

--- a/commands_setBuyAmount.go
+++ b/commands_setBuyAmount.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/distributeddesigns/currency"
+	types "github.com/distributeddesigns/shared_types"
 )
 
 type setBuyAmountCmd struct {
@@ -38,12 +39,8 @@ func (sba setBuyAmountCmd) Name() string {
 	return fmt.Sprintf("[%d] SET_BUY_AMOUNT", sba.id)
 }
 
-func (sba setBuyAmountCmd) GetUserID() string {
-	return sba.userID
-}
-
-func (sba setBuyAmountCmd) ToAuditEntry() string {
-	return fmt.Sprintf(`
+func (sba setBuyAmountCmd) ToAuditEvent() types.AuditEvent {
+	xmlElement := fmt.Sprintf(`
 	<userCommand>
 		<timestamp>%d</timestamp>
 		<server>%s</server>
@@ -56,6 +53,13 @@ func (sba setBuyAmountCmd) ToAuditEntry() string {
 		time.Now().UnixNano()/1e6, redisBaseKey, sba.id, sba.userID,
 		sba.stock, sba.amount.ToFloat(),
 	)
+
+	return types.AuditEvent{
+		UserID:    sba.userID,
+		ID:        sba.id,
+		EventType: "command",
+		Content:   xmlElement,
+	}
 }
 
 func (sba setBuyAmountCmd) Execute() {

--- a/commands_setBuyTrigger.go
+++ b/commands_setBuyTrigger.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/distributeddesigns/currency"
+	types "github.com/distributeddesigns/shared_types"
 )
 
 type setBuyTriggerCmd struct {
@@ -38,12 +39,8 @@ func (sbt setBuyTriggerCmd) Name() string {
 	return fmt.Sprintf("[%d] SET_BUY_TRIGGER", sbt.id)
 }
 
-func (sbt setBuyTriggerCmd) GetUserID() string {
-	return sbt.userID
-}
-
-func (sbt setBuyTriggerCmd) ToAuditEntry() string {
-	return fmt.Sprintf(`
+func (sbt setBuyTriggerCmd) ToAuditEvent() types.AuditEvent {
+	xmlElement := fmt.Sprintf(`
 	<userCommand>
 		<timestamp>%d</timestamp>
 		<server>%s</server>
@@ -56,6 +53,13 @@ func (sbt setBuyTriggerCmd) ToAuditEntry() string {
 		time.Now().UnixNano()/1e6, redisBaseKey, sbt.id, sbt.userID,
 		sbt.stock, sbt.amount.ToFloat(),
 	)
+
+	return types.AuditEvent{
+		UserID:    sbt.userID,
+		ID:        sbt.id,
+		EventType: "command",
+		Content:   xmlElement,
+	}
 }
 
 func (sbt setBuyTriggerCmd) Execute() {

--- a/commands_setSellAmount.go
+++ b/commands_setSellAmount.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/distributeddesigns/currency"
+	types "github.com/distributeddesigns/shared_types"
 )
 
 type setSellAmountCmd struct {
@@ -38,12 +39,8 @@ func (ssa setSellAmountCmd) Name() string {
 	return fmt.Sprintf("[%d] SET_SELL_AMOUNT", ssa.id)
 }
 
-func (ssa setSellAmountCmd) GetUserID() string {
-	return ssa.userID
-}
-
-func (ssa setSellAmountCmd) ToAuditEntry() string {
-	return fmt.Sprintf(`
+func (ssa setSellAmountCmd) ToAuditEvent() types.AuditEvent {
+	xmlElement := fmt.Sprintf(`
 	<userCommand>
 		<timestamp>%d</timestamp>
 		<server>%s</server>
@@ -56,6 +53,13 @@ func (ssa setSellAmountCmd) ToAuditEntry() string {
 		time.Now().UnixNano()/1e6, redisBaseKey, ssa.id, ssa.userID,
 		ssa.stock, ssa.amount.ToFloat(),
 	)
+
+	return types.AuditEvent{
+		UserID:    ssa.userID,
+		ID:        ssa.id,
+		EventType: "command",
+		Content:   xmlElement,
+	}
 }
 
 func (ssa setSellAmountCmd) Execute() {

--- a/commands_setSellTrigger.go
+++ b/commands_setSellTrigger.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/distributeddesigns/currency"
+	types "github.com/distributeddesigns/shared_types"
 )
 
 type setSellTriggerCmd struct {
@@ -38,12 +39,8 @@ func (sst setSellTriggerCmd) Name() string {
 	return fmt.Sprintf("[%d] SET_SELL_TRIGGER", sst.id)
 }
 
-func (sst setSellTriggerCmd) GetUserID() string {
-	return sst.userID
-}
-
-func (sst setSellTriggerCmd) ToAuditEntry() string {
-	return fmt.Sprintf(`
+func (sst setSellTriggerCmd) ToAuditEvent() types.AuditEvent {
+	xmlElement := fmt.Sprintf(`
 	<userCommand>
 		<timestamp>%d</timestamp>
 		<server>%s</server>
@@ -56,6 +53,13 @@ func (sst setSellTriggerCmd) ToAuditEntry() string {
 		time.Now().UnixNano()/1e6, redisBaseKey, sst.id, sst.userID,
 		sst.stock, sst.amount.ToFloat(),
 	)
+
+	return types.AuditEvent{
+		UserID:    sst.userID,
+		ID:        sst.id,
+		EventType: "command",
+		Content:   xmlElement,
+	}
 }
 
 func (sst setSellTriggerCmd) Execute() {

--- a/txWorker.go
+++ b/txWorker.go
@@ -88,8 +88,9 @@ func sendCmdToAudit() {
 			header := amqp.Table{
 				"name":      cmd.Name(),
 				"serviceID": redisBaseKey,
-				"userID":    cmd.GetUserID(),
 			}
+
+			ae := cmd.ToAuditEvent()
 
 			err := logChannel.Publish(
 				"",          // exchange
@@ -99,7 +100,7 @@ func sendCmdToAudit() {
 				amqp.Publishing{
 					Headers:     header,
 					ContentType: "text/plain",
-					Body:        []byte(cmd.ToAuditEntry()),
+					Body:        []byte(ae.ToCSV()),
 				})
 			failOnError(err, "Failed to publish a message")
 


### PR DESCRIPTION
In order to use PG for log durability the worker needs to send serialized `AuditEvent` objects that can be put into PG.

As a bonus, passing the user info in the `AuditEvent` cleans up the messiness introduced in 3a453be5e so we can close #19.

Works with audit_logger PR distributeddesigns/audit_logger#6