### PR TITLE
Buy / Sell

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -30,9 +30,7 @@ func newAccountForUser(userID string) *account {
 func (ac *account) AddFunds(amount currency.Currency) {
 	consoleLog.Debugf("Old balance for %s is %s", ac.userID, ac.balance)
 
-	ac.Lock()
 	ac.balance.Add(amount)
-	ac.Unlock()
 
 	consoleLog.Debugf("New balance for %s is %s", ac.userID, ac.balance)
 }
@@ -41,9 +39,7 @@ func (ac *account) AddFunds(amount currency.Currency) {
 func (ac *account) RemoveFunds(amount currency.Currency) error {
 	consoleLog.Debugf("Old balance for %s is %s", ac.userID, ac.balance)
 
-	ac.Lock()
 	err := ac.balance.Sub(amount)
-	ac.Unlock()
 
 	consoleLog.Debugf("New balance for %s is %s", ac.userID, ac.balance)
 
@@ -55,9 +51,7 @@ func (ac *account) AddStock(stock string, quantity uint64) {
 	consoleLog.Debugf("Old portfolio for %s: %d x %s",
 		ac.userID, ac.portfolio[stock], stock)
 
-	ac.Lock()
 	ac.portfolio[stock] += quantity
-	ac.Unlock()
 
 	consoleLog.Debugf("New portfolio for %s: %d x %s",
 		ac.userID, ac.portfolio[stock], stock)
@@ -65,11 +59,6 @@ func (ac *account) AddStock(stock string, quantity uint64) {
 
 // RemoveStock surrenders stock from the user's portfolio
 func (ac *account) RemoveStock(stock string, quantity uint64) error {
-	// Lock the account now so next check can be considered valid
-	// for length of function
-	ac.Lock()
-	defer ac.Unlock()
-
 	// Check to see if user can surrender that much stock
 	if ac.portfolio[stock] < quantity {
 		return errors.New("User does not have enough stock to surrender")

--- a/accounts.go
+++ b/accounts.go
@@ -85,3 +85,19 @@ func (ac *account) RemoveStock(stock string, quantity uint64) error {
 
 	return nil
 }
+
+// PruneExpiredTxs will remove all pendingTxs that are expired
+func (ac *account) PruneExpiredTxs() {
+	ac.Lock()
+	expiredBuys := ac.pendingBuys.SplitExpired()
+	expiredSells := ac.pendingSells.SplitExpired()
+	ac.Unlock()
+
+	for _, buy := range *expiredBuys {
+		buy.RollBack()
+	}
+
+	for _, sell := range *expiredSells {
+		sell.RollBack()
+	}
+}

--- a/accounts.go
+++ b/accounts.go
@@ -1,16 +1,29 @@
 package main
 
 import (
+	"errors"
 	"sync"
 
 	"github.com/distributeddesigns/currency"
 )
 
+type portfolio map[string]uint64
+
 // Account : State of a particular Account
 type account struct {
-	userID  string
-	balance currency.Currency
+	userID       string
+	balance      currency.Currency
+	portfolio    portfolio
+	pendingBuys  txStack
+	pendingSells txStack
 	sync.Mutex
+}
+
+// newAccountForUser creates an empty account for the given user
+func newAccountForUser(userID string) *account {
+	var ac = account{userID: userID}
+	ac.portfolio = make(portfolio)
+	return &ac
 }
 
 // AddFunds : Increases the balance of the account
@@ -35,4 +48,40 @@ func (ac *account) RemoveFunds(amount currency.Currency) error {
 	consoleLog.Debugf("New balance for %s is %s", ac.userID, ac.balance)
 
 	return err
+}
+
+// AddStock grants the user the specified amount of stock in their portfolio
+func (ac *account) AddStock(stock string, quantity uint64) {
+	consoleLog.Debugf("Old portfolio for %s: %d x %s",
+		ac.userID, ac.portfolio[stock], stock)
+
+	ac.Lock()
+	ac.portfolio[stock] += quantity
+	ac.Unlock()
+
+	consoleLog.Debugf("New portfolio for %s: %d x %s",
+		ac.userID, ac.portfolio[stock], stock)
+}
+
+// RemoveStock surrenders stock from the user's portfolio
+func (ac *account) RemoveStock(stock string, quantity uint64) error {
+	// Lock the account now so next check can be considered valid
+	// for length of function
+	ac.Lock()
+	defer ac.Unlock()
+
+	// Check to see if user can surrender that much stock
+	if ac.portfolio[stock] < quantity {
+		return errors.New("User does not have enough stock to surrender")
+	}
+
+	consoleLog.Debugf("Old portfolio for %s: %d x %s",
+		ac.userID, ac.portfolio[stock], stock)
+
+	ac.portfolio[stock] -= quantity
+
+	consoleLog.Debugf("New portfolio for %s: %d x %s",
+		ac.userID, ac.portfolio[stock], stock)
+
+	return nil
 }

--- a/commands_add.go
+++ b/commands_add.go
@@ -65,10 +65,12 @@ func (a addCmd) Execute() {
 		accountStore[a.userID] = newAccountForUser(a.userID)
 	}
 
-	userAccount := accountStore[a.userID]
+	acct := accountStore[a.userID]
 
 	consoleLog.Infof("Adding %s to %s", a.amount, a.userID)
-	userAccount.AddFunds(a.amount)
+	acct.Lock()
+	acct.AddFunds(a.amount)
+	acct.Unlock()
 
 	consoleLog.Notice(" [✔] Finished", a.Name())
 }

--- a/commands_add.go
+++ b/commands_add.go
@@ -62,7 +62,7 @@ func (a addCmd) Execute() {
 	// Create an account if one does not exist
 	if _, accountExists := accountStore[a.userID]; !accountExists {
 		consoleLog.Infof("Creating account for %s", a.userID)
-		accountStore[a.userID] = &account{userID: a.userID}
+		accountStore[a.userID] = newAccountForUser(a.userID)
 	}
 
 	userAccount := accountStore[a.userID]

--- a/commands_buy.go
+++ b/commands_buy.go
@@ -87,7 +87,7 @@ func (b buyCmd) Execute() {
 
 	// Check to make sure use has enough funds for buy
 	if acct.balance.ToFloat() < b.amount.ToFloat() {
-		abortTx("User does not have enough funds")
+		abortTx(b.Name() + " Insufficient funds")
 	}
 
 	// Get a fresh quote if quote is about to expire
@@ -102,7 +102,7 @@ func (b buyCmd) Execute() {
 	quantityToBuy, purchaseAmount := q.Price.FitsInto(b.amount)
 	consoleLog.Debugf("Want to buy %d stock", quantityToBuy)
 	if quantityToBuy < 1 {
-		abortTx("Cannot buy less than one stock")
+		abortTx(b.Name() + " Cannot buy less than one stock")
 	}
 
 	// If yes...

--- a/commands_buy.go
+++ b/commands_buy.go
@@ -65,6 +65,8 @@ func (b buyCmd) ToAuditEvent() types.AuditEvent {
 }
 
 func (b buyCmd) Execute() {
+	abortTxIfNoAccount(b.userID)
+
 	// Get a quote for the stock
 	qr := types.QuoteRequest{
 		Stock:      b.stock,

--- a/commands_buy.go
+++ b/commands_buy.go
@@ -108,17 +108,19 @@ func (b buyCmd) Execute() {
 	acct := accountStore[b.userID]
 	err = acct.RemoveFunds(purchaseAmount)
 	abortTxOnError(err, "User does not have enough funds to purchase stock")
-	acct.pendingBuys.push(b)
+	acct.pendingBuys.Push(b)
 
 	consoleLog.Notice(" [✔] Finished", b.Name())
 }
 
 func (b buyCmd) Commit() {
+	consoleLog.Debug("Commiting", b.Name())
 	acct := accountStore[b.userID]
 	acct.AddStock(b.stock, b.quantityToBuy)
 }
 
 func (b buyCmd) RollBack() {
+	consoleLog.Debug("Rolling back", b.Name())
 	acct := accountStore[b.userID]
 	acct.AddFunds(b.purchaseAmount)
 }

--- a/commands_buy.go
+++ b/commands_buy.go
@@ -81,15 +81,6 @@ func (b buyCmd) Execute() {
 
 	q := getQuote(qr)
 
-	acct := accountStore[b.userID]
-	acct.Lock()
-	defer acct.Unlock()
-
-	// Check to make sure use has enough funds for buy
-	if acct.balance.ToFloat() < b.amount.ToFloat() {
-		abortTx(b.Name() + " Insufficient funds")
-	}
-
 	// Get a fresh quote if quote is about to expire
 	quoteTTL := q.Timestamp.Add(time.Second*60).Unix() - time.Now().Unix()
 	if quoteTTL < config.QuotePolicy.UseInBuySell {
@@ -103,6 +94,15 @@ func (b buyCmd) Execute() {
 	consoleLog.Debugf("Want to buy %d stock", quantityToBuy)
 	if quantityToBuy < 1 {
 		abortTx(b.Name() + " Cannot buy less than one stock")
+	}
+
+	acct := accountStore[b.userID]
+	acct.Lock()
+	defer acct.Unlock()
+
+	// Check to make sure use has enough funds for buy
+	if acct.balance.ToFloat() < b.amount.ToFloat() {
+		abortTx(b.Name() + " Insufficient funds")
 	}
 
 	// If yes...

--- a/commands_buy.go
+++ b/commands_buy.go
@@ -10,10 +10,13 @@ import (
 )
 
 type buyCmd struct {
-	id     uint64
-	userID string
-	stock  string
-	amount currency.Currency
+	id             uint64
+	userID         string
+	stock          string
+	amount         currency.Currency
+	purchaseAmount currency.Currency
+	quoteTimestamp time.Time
+	quantityToBuy  uint64
 }
 
 func parseBuyCmd(parts []string) buyCmd {
@@ -62,5 +65,62 @@ func (b buyCmd) ToAuditEvent() types.AuditEvent {
 }
 
 func (b buyCmd) Execute() {
-	consoleLog.Warning("Not implemented: BUY")
+	// Get a quote for the stock
+	qr := types.QuoteRequest{
+		Stock:      b.stock,
+		UserID:     b.userID,
+		AllowCache: true,
+		ID:         b.id,
+	}
+
+	q := getQuote(qr)
+
+	// Get a fresh quote if quote is about to expire
+	quoteTTL := q.Timestamp.Add(time.Second*60).Unix() - time.Now().Unix()
+	if quoteTTL < config.QuotePolicy.UseInBuy {
+		consoleLog.Info(" [!] Getting a fresh quote for", b.Name())
+		qr.AllowCache = false
+		q = getQuote(qr)
+	}
+
+	// Check if user can buy any stock at quote price
+	quantityToBuy, remainder := q.Price.FitsInto(b.amount)
+	consoleLog.Debugf("Want to buy %d stock", quantityToBuy)
+	if quantityToBuy < 1 {
+		abortTx("Cannot buy less than one stock " + b.Name())
+	}
+
+	purchaseAmount := b.amount
+	err := purchaseAmount.Sub(remainder)
+	abortTxOnError(err, "Problem removing funds from user")
+
+	// If yes...
+	// 1. Populate the quantityToBuy, purchaseAmount and quoteTimestamp fields
+	// 2. Remove the funds from the user
+	// 3. Add the buyCmd to the account's pendingBuys stack
+
+	b.quantityToBuy = uint64(quantityToBuy)
+	b.purchaseAmount = purchaseAmount
+	b.quoteTimestamp = q.Timestamp
+
+	acct := accountStore[b.userID]
+	acct.RemoveFunds(purchaseAmount)
+	acct.pendingBuys.push(b)
+
+	consoleLog.Notice(" [✔] Finished", b.Name())
+}
+
+func (b buyCmd) Commit() {
+	acct := accountStore[b.userID]
+	acct.AddStock(b.stock, b.quantityToBuy)
+}
+
+func (b buyCmd) RollBack() {
+	acct := accountStore[b.userID]
+	acct.AddFunds(b.purchaseAmount)
+}
+
+func (b buyCmd) IsValid() bool {
+	expiry := b.quoteTimestamp.Add(time.Second * 60)
+	return time.Now().After(expiry)
 }

--- a/commands_cancelBuy.go
+++ b/commands_cancelBuy.go
@@ -56,7 +56,7 @@ func (cb cancelBuyCmd) Execute() {
 
 	// Pop buy from user's pendingBuys stack
 	acct := accountStore[cb.userID]
-	pendingBuy, err := acct.pendingBuys.pop()
+	pendingBuy, err := acct.pendingBuys.Pop()
 	abortTxOnError(err, "User has no pending buys")
 
 	pendingBuy.RollBack()

--- a/commands_cancelBuy.go
+++ b/commands_cancelBuy.go
@@ -54,7 +54,6 @@ func (cb cancelBuyCmd) ToAuditEvent() types.AuditEvent {
 func (cb cancelBuyCmd) Execute() {
 	abortTxIfNoAccount(cb.userID)
 
-	// Pop buy from user's pendingBuys stack
 	acct := accountStore[cb.userID]
 	pendingBuy, err := acct.pendingBuys.Pop()
 	abortTxOnError(err, cb.Name()+" No pending buys")

--- a/commands_cancelBuy.go
+++ b/commands_cancelBuy.go
@@ -57,7 +57,7 @@ func (cb cancelBuyCmd) Execute() {
 	// Pop buy from user's pendingBuys stack
 	acct := accountStore[cb.userID]
 	pendingBuy, err := acct.pendingBuys.Pop()
-	abortTxOnError(err, "User has no pending buys")
+	abortTxOnError(err, cb.Name()+" No pending buys")
 
 	pendingBuy.RollBack()
 

--- a/commands_cancelBuy.go
+++ b/commands_cancelBuy.go
@@ -52,5 +52,14 @@ func (cb cancelBuyCmd) ToAuditEvent() types.AuditEvent {
 }
 
 func (cb cancelBuyCmd) Execute() {
-	consoleLog.Warning("Not implemented: CANCEL_BUY")
+	abortTxIfNoAccount(cb.userID)
+
+	// Pop buy from user's pendingBuys stack
+	acct := accountStore[cb.userID]
+	pendingBuy, err := acct.pendingBuys.pop()
+	abortTxOnError(err, "User has no pending buys")
+
+	pendingBuy.RollBack()
+
+	consoleLog.Notice(" [✔] Finished", cb.Name())
 }

--- a/commands_cancelSell.go
+++ b/commands_cancelSell.go
@@ -55,7 +55,7 @@ func (cs cancelSellCmd) Execute() {
 	abortTxIfNoAccount(cs.userID)
 
 	acct := accountStore[cs.userID]
-	pendingSell, err := acct.pendingSells.pop()
+	pendingSell, err := acct.pendingSells.Pop()
 	abortTxOnError(err, "User has no pending sells")
 
 	pendingSell.RollBack()

--- a/commands_cancelSell.go
+++ b/commands_cancelSell.go
@@ -52,5 +52,13 @@ func (cs cancelSellCmd) ToAuditEvent() types.AuditEvent {
 }
 
 func (cs cancelSellCmd) Execute() {
-	consoleLog.Warning("Not implemented: CANCEL_SELL")
+	abortTxIfNoAccount(cs.userID)
+
+	acct := accountStore[cs.userID]
+	pendingSell, err := acct.pendingSells.pop()
+	abortTxOnError(err, "User has no pending sells")
+
+	pendingSell.RollBack()
+
+	consoleLog.Notice(" [✔] Finished", cs.Name())
 }

--- a/commands_cancelSell.go
+++ b/commands_cancelSell.go
@@ -56,7 +56,7 @@ func (cs cancelSellCmd) Execute() {
 
 	acct := accountStore[cs.userID]
 	pendingSell, err := acct.pendingSells.Pop()
-	abortTxOnError(err, "User has no pending sells")
+	abortTxOnError(err, cs.Name()+" No pending sells")
 
 	pendingSell.RollBack()
 

--- a/commands_commitBuy.go
+++ b/commands_commitBuy.go
@@ -56,11 +56,11 @@ func (cb commitBuyCmd) Execute() {
 
 	acct := accountStore[cb.userID]
 	pendingBuy, err := acct.pendingBuys.Pop()
-	abortTxOnError(err, "User has no pending buys")
+	abortTxOnError(err, cb.Name()+" No pending buys")
 
 	if pendingBuy.IsExpired() {
 		pendingBuy.RollBack()
-		abortTx("Buy is expired")
+		abortTx(cb.Name() + " Buy expired")
 	}
 
 	pendingBuy.Commit()

--- a/commands_commitBuy.go
+++ b/commands_commitBuy.go
@@ -55,7 +55,7 @@ func (cb commitBuyCmd) Execute() {
 	abortTxIfNoAccount(cb.userID)
 
 	acct := accountStore[cb.userID]
-	pendingBuy, err := acct.pendingBuys.pop()
+	pendingBuy, err := acct.pendingBuys.Pop()
 	abortTxOnError(err, "User has no pending buys")
 
 	if pendingBuy.IsExpired() {

--- a/commands_commitBuy.go
+++ b/commands_commitBuy.go
@@ -52,5 +52,14 @@ func (cb commitBuyCmd) ToAuditEvent() types.AuditEvent {
 }
 
 func (cb commitBuyCmd) Execute() {
-	consoleLog.Warning("Not implemented: COMMIT_BUY")
+	abortTxIfNoAccount(cb.userID)
+
+	// Pop buy from user's pendingBuys stack
+	acct := accountStore[cb.userID]
+	pendingBuy, err := acct.pendingBuys.pop()
+	abortTxOnError(err, "User has no pending buys")
+
+	pendingBuy.Commit()
+
+	consoleLog.Notice(" [✔] Finished", cb.Name())
 }

--- a/commands_commitBuy.go
+++ b/commands_commitBuy.go
@@ -54,10 +54,13 @@ func (cb commitBuyCmd) ToAuditEvent() types.AuditEvent {
 func (cb commitBuyCmd) Execute() {
 	abortTxIfNoAccount(cb.userID)
 
-	// Pop buy from user's pendingBuys stack
 	acct := accountStore[cb.userID]
 	pendingBuy, err := acct.pendingBuys.pop()
 	abortTxOnError(err, "User has no pending buys")
+
+	if pendingBuy.IsExpired() {
+		abortTx("Buy is expired")
+	}
 
 	pendingBuy.Commit()
 

--- a/commands_commitBuy.go
+++ b/commands_commitBuy.go
@@ -59,6 +59,7 @@ func (cb commitBuyCmd) Execute() {
 	abortTxOnError(err, "User has no pending buys")
 
 	if pendingBuy.IsExpired() {
+		pendingBuy.RollBack()
 		abortTx("Buy is expired")
 	}
 

--- a/commands_commitSell.go
+++ b/commands_commitSell.go
@@ -55,7 +55,7 @@ func (cs commitSellCmd) Execute() {
 	abortTxIfNoAccount(cs.userID)
 
 	acct := accountStore[cs.userID]
-	pendingSell, err := acct.pendingSells.pop()
+	pendingSell, err := acct.pendingSells.Pop()
 	abortTxOnError(err, "User has no pending sells")
 
 	if pendingSell.IsExpired() {

--- a/commands_commitSell.go
+++ b/commands_commitSell.go
@@ -56,11 +56,11 @@ func (cs commitSellCmd) Execute() {
 
 	acct := accountStore[cs.userID]
 	pendingSell, err := acct.pendingSells.Pop()
-	abortTxOnError(err, "User has no pending sells")
+	abortTxOnError(err, cs.Name()+" No pending sells")
 
 	if pendingSell.IsExpired() {
 		pendingSell.RollBack()
-		abortTx("Sell is expired")
+		abortTx(cs.Name() + " Sell is expired")
 	}
 
 	pendingSell.Commit()

--- a/commands_commitSell.go
+++ b/commands_commitSell.go
@@ -52,5 +52,17 @@ func (cs commitSellCmd) ToAuditEvent() types.AuditEvent {
 }
 
 func (cs commitSellCmd) Execute() {
-	consoleLog.Warning("Not implemented: COMMIT_SELL")
+	abortTxIfNoAccount(cs.userID)
+
+	acct := accountStore[cs.userID]
+	pendingSell, err := acct.pendingSells.pop()
+	abortTxOnError(err, "User has no pending sells")
+
+	if pendingSell.IsExpired() {
+		abortTx("Sell is expired")
+	}
+
+	pendingSell.Commit()
+
+	consoleLog.Notice(" [✔] Finished", cs.Name())
 }

--- a/commands_commitSell.go
+++ b/commands_commitSell.go
@@ -59,6 +59,7 @@ func (cs commitSellCmd) Execute() {
 	abortTxOnError(err, "User has no pending sells")
 
 	if pendingSell.IsExpired() {
+		pendingSell.RollBack()
 		abortTx("Sell is expired")
 	}
 

--- a/commands_sell.go
+++ b/commands_sell.go
@@ -114,17 +114,19 @@ func (s sellCmd) Execute() {
 
 	err := acct.RemoveStock(s.stock, s.quantityToSell)
 	abortTxOnError(err, "User does not have enough stock to sell")
-	acct.pendingSells.push(s)
+	acct.pendingSells.Push(s)
 
 	consoleLog.Notice(" [✔] Finished", s.Name())
 }
 
 func (s sellCmd) Commit() {
+	consoleLog.Debug("Commiting", s.Name())
 	acct := accountStore[s.userID]
 	acct.AddFunds(s.profit)
 }
 
 func (s sellCmd) RollBack() {
+	consoleLog.Debug("Rolling back", s.Name())
 	acct := accountStore[s.userID]
 	acct.AddStock(s.stock, s.quantityToSell)
 }

--- a/commands_sell.go
+++ b/commands_sell.go
@@ -113,7 +113,7 @@ func (s sellCmd) Execute() {
 	s.expiresAt = q.Timestamp.Add(time.Second * 60)
 
 	err := acct.RemoveStock(s.stock, s.quantityToSell)
-	abortTxOnError(err, s.Name()+" User does not have enough stock to sell")
+	abortTxOnError(err, s.Name())
 	acct.pendingSells.Push(s)
 
 	consoleLog.Notice(" [✔] Finished", s.Name())

--- a/commands_sell.go
+++ b/commands_sell.go
@@ -75,7 +75,7 @@ func (s sellCmd) Execute() {
 	// Check if user has any stock, abort early
 	stockHoldings, found := acct.portfolio[s.stock]
 	if !found || stockHoldings == 0 {
-		abortTx("User does not have any stock to sell")
+		abortTx(s.Name() + " User does not have any stock to sell")
 	}
 
 	// Get a quote for the stock
@@ -100,7 +100,7 @@ func (s sellCmd) Execute() {
 	quantityToSell, profit := q.Price.FitsInto(s.amount)
 	consoleLog.Debugf("Want to sell %d stock", quantityToSell)
 	if quantityToSell < 1 {
-		abortTx("Cannot sell less than one stock")
+		abortTx(s.Name() + "Cannot sell less than one stock")
 	}
 
 	// If yes...
@@ -113,7 +113,7 @@ func (s sellCmd) Execute() {
 	s.expiresAt = q.Timestamp.Add(time.Second * 60)
 
 	err := acct.RemoveStock(s.stock, s.quantityToSell)
-	abortTxOnError(err, "User does not have enough stock to sell")
+	abortTxOnError(err, s.Name()+" User does not have enough stock to sell")
 	acct.pendingSells.Push(s)
 
 	consoleLog.Notice(" [✔] Finished", s.Name())

--- a/commands_sell.go
+++ b/commands_sell.go
@@ -95,7 +95,7 @@ func (s sellCmd) Execute() {
 
 	// Check if user can sell stock at quote price
 	quantityToSell, _ := q.Price.FitsInto(s.amount)
-	consoleLog.Debugf("Want to sell %s stock", quantityToSell)
+	consoleLog.Debugf("Want to sell %d stock", quantityToSell)
 	if quantityToSell < 1 {
 		abortTx("Cannot sell less than one stock")
 	}

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -21,4 +21,4 @@ quote policy:
   base ttl: 59
   backoff ttl: 4 # ranges 0 -> n
   min ttl: 3 # Don't cache quotes with less than this TTL
-  use with buy: 3 # Get a new quote for a buy if TTL smaller than this
+  use in buy sell: 3 # Get a new quote for a buy if TTL smaller than this

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -22,3 +22,7 @@ quote policy:
   backoff ttl: 4 # ranges 0 -> n
   min ttl: 3 # Don't cache quotes with less than this TTL
   use in buy sell: 3 # Get a new quote for a buy if TTL smaller than this
+
+# How often user accounts will be crawled for removal of expired
+# pending buy / sells
+cleanup interval: 60 # seconda

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -21,3 +21,4 @@ quote policy:
   base ttl: 59
   backoff ttl: 4 # ranges 0 -> n
   min ttl: 3 # Don't cache quotes with less than this TTL
+  use with buy: 3 # Get a new quote for a buy if TTL smaller than this

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -16,3 +16,4 @@ quote policy:
   base ttl: 59
   backoff ttl: 4
   min ttl: 3
+  use with buy: 3

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -16,4 +16,4 @@ quote policy:
   base ttl: 59
   backoff ttl: 4
   min ttl: 3
-  use with buy: 3
+  use in buy sell: 3

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -17,3 +17,5 @@ quote policy:
   backoff ttl: 4
   min ttl: 3
   use in buy sell: 3
+
+cleanup interval: 60

--- a/main.go
+++ b/main.go
@@ -142,10 +142,10 @@ var config struct {
 	}
 
 	QuotePolicy struct {
-		BaseTTL    int   `yaml:"base ttl"`
-		BackoffTTL int   `yaml:"backoff ttl"`
-		MinTTL     int   `yaml:"min ttl"`
-		UseInBuy   int64 `yaml:"use in buy"`
+		BaseTTL      int   `yaml:"base ttl"`
+		BackoffTTL   int   `yaml:"backoff ttl"`
+		MinTTL       int   `yaml:"min ttl"`
+		UseInBuySell int64 `yaml:"use in buy sell"`
 	} `yaml:"quote policy"`
 }
 

--- a/main.go
+++ b/main.go
@@ -142,9 +142,10 @@ var config struct {
 	}
 
 	QuotePolicy struct {
-		BaseTTL    int `yaml:"base ttl"`
-		BackoffTTL int `yaml:"backoff ttl"`
-		MinTTL     int `yaml:"min ttl"`
+		BaseTTL    int   `yaml:"base ttl"`
+		BackoffTTL int   `yaml:"backoff ttl"`
+		MinTTL     int   `yaml:"min ttl"`
+		UseInBuy   int64 `yaml:"use in buy"`
 	} `yaml:"quote policy"`
 }
 

--- a/pendingTx.go
+++ b/pendingTx.go
@@ -1,0 +1,7 @@
+package main
+
+type pendingTx interface {
+	Commit()
+	RollBack()
+	IsValid() bool
+}

--- a/pendingTx.go
+++ b/pendingTx.go
@@ -3,5 +3,5 @@ package main
 type pendingTx interface {
 	Commit()
 	RollBack()
-	IsValid() bool
+	IsExpired() bool
 }

--- a/stack.go
+++ b/stack.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"errors"
+)
+
+type txStack []pendingTx
+
+func (s txStack) isEmpty() bool {
+	return len(s) == 0
+}
+
+func (s *txStack) push(ptx pendingTx) {
+	(*s) = append(*s, ptx)
+}
+
+func (s *txStack) pop() (pendingTx, error) {
+	var ptx pendingTx
+	if (*s).isEmpty() {
+		return ptx, errors.New("Empty txStack")
+	}
+
+	ptx = (*s)[len(*s)-1]
+	*s = (*s)[:len(*s)-1]
+
+	return ptx, nil
+}
+
+func (s txStack) peek() (pendingTx, error) {
+	var ptx pendingTx
+	if s.isEmpty() {
+		return ptx, errors.New("Empty txStack")
+	}
+
+	return s[len(s)-1], nil
+}

--- a/stack.go
+++ b/stack.go
@@ -6,17 +6,17 @@ import (
 
 type txStack []pendingTx
 
-func (s txStack) isEmpty() bool {
-	return len(s) == 0
+func (s *txStack) IsEmpty() bool {
+	return len(*s) == 0
 }
 
-func (s *txStack) push(ptx pendingTx) {
+func (s *txStack) Push(ptx pendingTx) {
 	(*s) = append(*s, ptx)
 }
 
-func (s *txStack) pop() (pendingTx, error) {
+func (s *txStack) Pop() (pendingTx, error) {
 	var ptx pendingTx
-	if (*s).isEmpty() {
+	if s.IsEmpty() {
 		return ptx, errors.New("Empty txStack")
 	}
 
@@ -26,11 +26,22 @@ func (s *txStack) pop() (pendingTx, error) {
 	return ptx, nil
 }
 
-func (s txStack) peek() (pendingTx, error) {
-	var ptx pendingTx
-	if s.isEmpty() {
-		return ptx, errors.New("Empty txStack")
+func (s *txStack) SplitExpired() *txStack {
+	var expiredTxs txStack
+	if s.IsEmpty() {
+		return &expiredTxs
 	}
 
-	return s[len(s)-1], nil
+	// Determine position of first expired item, then split stack
+	var i int
+	for i = 0; i < len(*s); i++ {
+		if !(*s)[i].IsExpired() {
+			break
+		}
+	}
+
+	expiredTxs = (*s)[:i]
+	*s = (*s)[i:]
+
+	return &expiredTxs
 }

--- a/txWorker.go
+++ b/txWorker.go
@@ -63,6 +63,12 @@ func catchAbortedTx() {
 	}
 }
 
+func abortTxIfNoAccount(userID string) {
+	if _, found := accountStore[userID]; !found {
+		panic("Cannot perform this command on users without an account")
+	}
+}
+
 func cleanUpTxs(unprocessedTxs <-chan string) {
 	// TODO: Put these back in redis? Just warn for now.
 	if len(unprocessedTxs) > 0 {


### PR DESCRIPTION
[Here's a log of the run](https://gist.github.com/trstephen/e12e31c20752d1aa77fbe364a03b96ce)

### Overview
 `Buy` and `Sell` commands implement the `pendingTx` interface which grants `Commit()` and `RollBack()` functionality. When a buy/sell is processed it's added to a user's `pendingBuy`/`pendingSell` stack. Commit / Cancel actions pop the top of the respective stack and call the appropriate function. At fixed intervals, a cleanup function wakes up and rolls back all expired transactions in the user store.

### Other tidbits
- I pulled the locks out of `accounts.go` functions because having to lock/unlock before calling one of those functions was 1) a pain in the ass, and 2) defeating the purpose of the lock, which is to guarantee account state for the duration of a transaction.
- `newAccountForUser(userID)` consolidates the account setup stuff. Previously it was chilling out in `Add` which was... weird.