### PR TITLE
Use static port for websocket conns

### DIFF
--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -26,3 +26,5 @@ quote policy:
 # How often user accounts will be crawled for removal of expired
 # pending buy / sells
 cleanup interval: 60 # seconda
+
+websocket port: 44433

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -19,3 +19,4 @@ quote policy:
   use in buy sell: 3
 
 cleanup interval: 60
+websocket port: 44433

--- a/main.go
+++ b/main.go
@@ -152,6 +152,7 @@ var config struct {
 	} `yaml:"quote policy"`
 
 	CleanupInterval int `yaml:"cleanup interval"`
+	WebSocketPort   int `yaml:"websocket port"`
 }
 
 func loadConfig() {


### PR DESCRIPTION
44432 conflicts with the DB. Dynamic conn numbers aren't an issue in production since workers are on separate VMs (and determining the correct port to open would be painful...). Can still run multiple workers locally by creating separate `dev1.yaml`, `dev2.yaml`, etc. and using them with the worker `-c` flag to specify the config file.

**New websocket port is 44433**