### PR TITLE
Pass errors to socket

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -23,7 +23,7 @@ func parseCommand(s string) command {
 	parts := strings.Split(csv, ",")
 
 	if len(parts) < 3 {
-		abortTx("Insufficient command arguments")
+		abortParse("Insufficient command arguments")
 	}
 
 	cmdType := parts[1]
@@ -63,7 +63,7 @@ func parseCommand(s string) command {
 	case "DUMPLOG":
 		parsedCommand = parseDumplogCmd(parts)
 	default:
-		abortTx(fmt.Sprintf("Unrecognized command %s: %+v", cmdType, parts))
+		abortParse(fmt.Sprintf("Unrecognized command %s: %+v", cmdType, parts))
 	}
 
 	return parsedCommand

--- a/commands_add.go
+++ b/commands_add.go
@@ -17,14 +17,14 @@ type addCmd struct {
 
 func parseAddCmd(parts []string) addCmd {
 	if len(parts) != 4 {
-		abortTx("ADD needs 4 parts")
+		abortParse("ADD needs 4 parts")
 	}
 
 	txID, err := strconv.ParseUint(parts[0], 10, 64)
-	abortTxOnError(err, "Could not parse ID")
+	abortParseOnError(err, "Could not parse ID")
 
 	amount, err := currency.NewFromString(parts[3])
-	abortTxOnError(err, "Could not parse amount in transaction")
+	abortParseOnError(err, "Could not parse amount in transaction")
 
 	return addCmd{
 		id:     txID,

--- a/commands_buy.go
+++ b/commands_buy.go
@@ -117,6 +117,7 @@ func (b buyCmd) Execute() {
 	abortTxOnError(err, b.userID, "This should be impossible!")
 	acct.pendingBuys.Push(b)
 
+	acct.PushEvent(fmt.Sprintf("Want to buy %d of %s for %s", b.quantityToBuy, b.stock, b.purchaseAmount))
 	acct.AddSummaryItem("Finished " + b.Name())
 	consoleLog.Notice(" [✔] Finished", b.Name())
 }

--- a/commands_cancelBuy.go
+++ b/commands_cancelBuy.go
@@ -15,11 +15,11 @@ type cancelBuyCmd struct {
 
 func parseCancelBuyCmd(parts []string) cancelBuyCmd {
 	if len(parts) != 3 {
-		abortTx("CANCEL_BUY needs 3 parts")
+		abortParse("CANCEL_BUY needs 3 parts")
 	}
 
 	id, err := strconv.ParseUint(parts[0], 10, 64)
-	abortTxOnError(err, "Could not parse ID")
+	abortParseOnError(err, "Could not parse ID")
 
 	return cancelBuyCmd{
 		id:     id,
@@ -56,7 +56,7 @@ func (cb cancelBuyCmd) Execute() {
 
 	acct := accountStore[cb.userID]
 	pendingBuy, err := acct.pendingBuys.Pop()
-	abortTxOnError(err, cb.Name()+" No pending buys")
+	abortTxOnError(err, cb.userID, cb.Name()+" No pending buys")
 
 	pendingBuy.RollBack()
 

--- a/commands_cancelSell.go
+++ b/commands_cancelSell.go
@@ -15,11 +15,11 @@ type cancelSellCmd struct {
 
 func parseCancelSellCmd(parts []string) cancelSellCmd {
 	if len(parts) != 3 {
-		abortTx("CANCEL_SELL needs 3 parts")
+		abortParse("CANCEL_SELL needs 3 parts")
 	}
 
 	id, err := strconv.ParseUint(parts[0], 10, 64)
-	abortTxOnError(err, "Could not parse ID")
+	abortParseOnError(err, "Could not parse ID")
 
 	return cancelSellCmd{
 		id:     id,
@@ -56,7 +56,7 @@ func (cs cancelSellCmd) Execute() {
 
 	acct := accountStore[cs.userID]
 	pendingSell, err := acct.pendingSells.Pop()
-	abortTxOnError(err, cs.Name()+" No pending sells")
+	abortTxOnError(err, cs.userID, cs.Name()+" No pending sells")
 
 	pendingSell.RollBack()
 

--- a/commands_cancelSetBuy.go
+++ b/commands_cancelSetBuy.go
@@ -16,11 +16,11 @@ type cancelSetBuyCmd struct {
 
 func parseCancelSetBuyCmd(parts []string) cancelSetBuyCmd {
 	if len(parts) != 4 {
-		abortTx("CANCEL_SET_BUY needs 4 parts")
+		abortParse("CANCEL_SET_BUY needs 4 parts")
 	}
 
 	id, err := strconv.ParseUint(parts[0], 10, 64)
-	abortTxOnError(err, "Could not parse ID")
+	abortParseOnError(err, "Could not parse ID")
 
 	return cancelSetBuyCmd{
 		id:     id,
@@ -63,5 +63,8 @@ func (csb cancelSetBuyCmd) Execute() {
 	delete(workATXStore, autoTxKey)
 	autoTxCancelChan <- autoTxKey
 	consoleLog.Debugf("Published aTx %v successfully", autoTxKey)
+
+	acct := accountStore[csb.userID]
+	acct.AddSummaryItem("Finished " + csb.Name())
 	consoleLog.Notice(" [✔] Finished", csb.Name())
 }

--- a/commands_cancelSetSell.go
+++ b/commands_cancelSetSell.go
@@ -16,11 +16,11 @@ type cancelSetSellCmd struct {
 
 func parseCancelSetSellCmd(parts []string) cancelSetSellCmd {
 	if len(parts) != 4 {
-		abortTx("CANCEL_SET_SELL needs 4 parts")
+		abortParse("CANCEL_SET_SELL needs 4 parts")
 	}
 
 	id, err := strconv.ParseUint(parts[0], 10, 64)
-	abortTxOnError(err, "Could not parse ID")
+	abortParseOnError(err, "Could not parse ID")
 
 	return cancelSetSellCmd{
 		id:     id,
@@ -63,5 +63,8 @@ func (css cancelSetSellCmd) Execute() {
 	delete(workATXStore, autoTxKey)
 	autoTxCancelChan <- autoTxKey
 	consoleLog.Debugf("Published aTx %v successfully", autoTxKey)
+
+	acct := accountStore[css.userID]
+	acct.AddSummaryItem("Finished " + css.Name())
 	consoleLog.Notice(" [✔] Finished", css.Name())
 }

--- a/commands_commitBuy.go
+++ b/commands_commitBuy.go
@@ -15,11 +15,11 @@ type commitBuyCmd struct {
 
 func parseCommitBuyCmd(parts []string) commitBuyCmd {
 	if len(parts) != 3 {
-		abortTx("COMMIT_BUY needs 3 parts")
+		abortParse("COMMIT_BUY needs 3 parts")
 	}
 
 	id, err := strconv.ParseUint(parts[0], 10, 64)
-	abortTxOnError(err, "Could not parse ID")
+	abortParseOnError(err, "Could not parse ID")
 
 	return commitBuyCmd{
 		id:     id,
@@ -56,11 +56,11 @@ func (cb commitBuyCmd) Execute() {
 
 	acct := accountStore[cb.userID]
 	pendingBuy, err := acct.pendingBuys.Pop()
-	abortTxOnError(err, cb.Name()+" No pending buys")
+	abortTxOnError(err, cb.userID, cb.Name()+" No pending buys")
 
 	if pendingBuy.IsExpired() {
 		pendingBuy.RollBack()
-		abortTx(cb.Name() + " Buy expired")
+		abortTx(cb.userID, cb.Name()+" Buy expired")
 	}
 
 	pendingBuy.Commit()

--- a/commands_commitSell.go
+++ b/commands_commitSell.go
@@ -15,11 +15,11 @@ type commitSellCmd struct {
 
 func parseCommitSellCmd(parts []string) commitSellCmd {
 	if len(parts) != 3 {
-		abortTx("COMMIT_SELL needs 3 parts")
+		abortParse("COMMIT_SELL needs 3 parts")
 	}
 
 	id, err := strconv.ParseUint(parts[0], 10, 64)
-	abortTxOnError(err, "Could not parse ID")
+	abortParseOnError(err, "Could not parse ID")
 
 	return commitSellCmd{
 		id:     id,
@@ -56,11 +56,11 @@ func (cs commitSellCmd) Execute() {
 
 	acct := accountStore[cs.userID]
 	pendingSell, err := acct.pendingSells.Pop()
-	abortTxOnError(err, cs.Name()+" No pending sells")
+	abortTxOnError(err, cs.userID, cs.Name()+" No pending sells")
 
 	if pendingSell.IsExpired() {
 		pendingSell.RollBack()
-		abortTx(cs.Name() + " Sell is expired")
+		abortTx(cs.userID, cs.Name()+" Sell is expired")
 	}
 
 	pendingSell.Commit()

--- a/commands_displaySummary.go
+++ b/commands_displaySummary.go
@@ -15,11 +15,11 @@ type displaySummaryCmd struct {
 
 func parseDisplaySummaryCmd(parts []string) displaySummaryCmd {
 	if len(parts) != 3 {
-		abortTx("DISPLAY_SUMMARY needs 3 parts")
+		abortParse("DISPLAY_SUMMARY needs 3 parts")
 	}
 
 	id, err := strconv.ParseUint(parts[0], 10, 64)
-	abortTxOnError(err, "Could not parse ID")
+	abortParseOnError(err, "Could not parse ID")
 
 	return displaySummaryCmd{
 		id:     id,

--- a/commands_dumplog.go
+++ b/commands_dumplog.go
@@ -20,11 +20,11 @@ type dumplogCmd struct {
 
 func parseDumplogCmd(parts []string) dumplogCmd {
 	if len(parts) < 3 {
-		abortTx("DUMPLOG needs at least 3 parts")
+		abortParse("DUMPLOG needs at least 3 parts")
 	}
 
 	id, err := strconv.ParseUint(parts[0], 10, 64)
-	abortTxOnError(err, "Could not parse ID")
+	abortParseOnError(err, "Could not parse ID")
 
 	// Dumplog is overloaded as
 	// 1) DUMPLOG,$filename

--- a/commands_dumplog.go
+++ b/commands_dumplog.go
@@ -101,7 +101,7 @@ func (dl dumplogCmd) Execute() {
 	consoleLog.Debug("Dumplog requested as", dlr.Filename)
 
 	acct := accountStore[dl.userID]
-	acct.PushEvent("Wrote dumplog to " + dlr.Filename)
+	acct.PushEvent(fmt.Sprintf("Wrote dumplog to %s\nContact an admin to retrieve your file", dlr.Filename))
 	acct.AddSummaryItem("Finished " + dl.Name())
 
 	consoleLog.Notice(" [✔] Finished", dl.Name())

--- a/commands_quote.go
+++ b/commands_quote.go
@@ -16,11 +16,11 @@ type quoteCmd struct {
 
 func parseQuoteCmd(parts []string) quoteCmd {
 	if len(parts) != 4 {
-		abortTx("QUOTE needs 4 parts")
+		abortParse("QUOTE needs 4 parts")
 	}
 
 	id, err := strconv.ParseUint(parts[0], 10, 64)
-	abortTxOnError(err, "Could not parse ID")
+	abortParseOnError(err, "Could not parse ID")
 
 	return quoteCmd{
 		id:     id,

--- a/commands_sell.go
+++ b/commands_sell.go
@@ -21,14 +21,14 @@ type sellCmd struct {
 
 func parseSellCmd(parts []string) sellCmd {
 	if len(parts) != 5 {
-		abortTx("SELL needs 5 parts")
+		abortParse("SELL needs 5 parts")
 	}
 
 	id, err := strconv.ParseUint(parts[0], 10, 64)
-	abortTxOnError(err, "Could not parse ID")
+	abortParseOnError(err, "Could not parse ID")
 
 	amount, err := currency.NewFromString(parts[4])
-	abortTxOnError(err, "Could not parse amount in transaction")
+	abortParseOnError(err, "Could not parse amount in transaction")
 
 	return sellCmd{
 		id:     id,
@@ -75,7 +75,7 @@ func (s sellCmd) Execute() {
 	// Check if user has any stock, abort early
 	stockHoldings, found := acct.portfolio[s.stock]
 	if !found || stockHoldings == 0 {
-		abortTx(s.Name() + " User does not have any stock to sell")
+		abortTx(s.userID, s.Name()+" User does not have any stock to sell")
 	}
 
 	// Get a quote for the stock
@@ -100,7 +100,7 @@ func (s sellCmd) Execute() {
 	quantityToSell, profit := q.Price.FitsInto(s.amount)
 	consoleLog.Debugf("Want to sell %d stock", quantityToSell)
 	if quantityToSell < 1 {
-		abortTx(s.Name() + " Cannot sell less than one stock")
+		abortTx(s.userID, s.Name()+" Cannot sell less than one stock")
 	}
 
 	// If yes...
@@ -113,7 +113,7 @@ func (s sellCmd) Execute() {
 	s.expiresAt = q.Timestamp.Add(time.Second * 60)
 
 	err := acct.RemoveStock(s.stock, s.quantityToSell)
-	abortTxOnError(err, s.Name())
+	abortTxOnError(err, s.userID, s.Name())
 	acct.pendingSells.Push(s)
 
 	acct.AddSummaryItem("Finished " + s.Name())

--- a/commands_sell.go
+++ b/commands_sell.go
@@ -94,6 +94,7 @@ func (s sellCmd) Execute() {
 		consoleLog.Info(" [!] Getting a fresh quote for", s.Name())
 		qr.AllowCache = false
 		q = getQuote(qr)
+		acct.PushEvent(fmt.Sprintf("New value for %s is %s", q.Stock, q.Price))
 	}
 
 	// Check if user can sell stock at quote price
@@ -116,6 +117,7 @@ func (s sellCmd) Execute() {
 	abortTxOnError(err, s.userID, s.Name())
 	acct.pendingSells.Push(s)
 
+	acct.PushEvent(fmt.Sprintf("Want to sell %d of %s for %s", s.quantityToSell, s.stock, s.profit))
 	acct.AddSummaryItem("Finished " + s.Name())
 	consoleLog.Notice(" [✔] Finished", s.Name())
 }

--- a/commands_setBuyAmount.go
+++ b/commands_setBuyAmount.go
@@ -18,14 +18,14 @@ type setBuyAmountCmd struct {
 
 func parseSetBuyAmountCmd(parts []string) setBuyAmountCmd {
 	if len(parts) != 5 {
-		abortTx("SET_BUY_AMOUNT needs 5 parts")
+		abortParse("SET_BUY_AMOUNT needs 5 parts")
 	}
 
 	id, err := strconv.ParseUint(parts[0], 10, 64)
-	abortTxOnError(err, "Could not parse ID")
+	abortParseOnError(err, "Could not parse ID")
 
 	amount, err := currency.NewFromString(parts[4])
-	abortTxOnError(err, "Could not parse amount in transaction")
+	abortParseOnError(err, "Could not parse amount in transaction")
 
 	return setBuyAmountCmd{
 		id:     id,
@@ -79,5 +79,8 @@ func (sba setBuyAmountCmd) Execute() {
 		Amount:    sba.amount,
 		WorkerID:  *workerNum,
 	}
+
+	acct := accountStore[sba.userID]
+	acct.AddSummaryItem("Finished " + sba.Name())
 	consoleLog.Notice(" [✔] Finished", sba.Name())
 }

--- a/commands_setBuyTrigger.go
+++ b/commands_setBuyTrigger.go
@@ -18,14 +18,14 @@ type setBuyTriggerCmd struct {
 
 func parseSetBuyTriggerCmd(parts []string) setBuyTriggerCmd {
 	if len(parts) != 5 {
-		abortTx("SET_BUY_TRIGGER needs 5 parts")
+		abortParse("SET_BUY_TRIGGER needs 5 parts")
 	}
 
 	id, err := strconv.ParseUint(parts[0], 10, 64)
-	abortTxOnError(err, "Could not parse ID")
+	abortParseOnError(err, "Could not parse ID")
 
 	amount, err := currency.NewFromString(parts[4])
-	abortTxOnError(err, "Could not parse amount in transaction")
+	abortParseOnError(err, "Could not parse amount in transaction")
 
 	return setBuyTriggerCmd{
 		id:     id,
@@ -79,5 +79,8 @@ func (sbt setBuyTriggerCmd) Execute() {
 	autoTx.Trigger = sbt.amount
 	autoTxInitChan <- autoTx
 	consoleLog.Debugf("Published aTx %v successfully", autoTx)
+
+	acct := accountStore[sbt.userID]
+	acct.AddSummaryItem("Finished " + sbt.Name())
 	consoleLog.Notice(" [✔] Finished", sbt.Name())
 }

--- a/commands_setSellAmount.go
+++ b/commands_setSellAmount.go
@@ -18,14 +18,14 @@ type setSellAmountCmd struct {
 
 func parseSetSellAmountCmd(parts []string) setSellAmountCmd {
 	if len(parts) != 5 {
-		abortTx("SET_SELL_AMOUNT needs 5 parts")
+		abortParse("SET_SELL_AMOUNT needs 5 parts")
 	}
 
 	id, err := strconv.ParseUint(parts[0], 10, 64)
-	abortTxOnError(err, "Could not parse ID")
+	abortParseOnError(err, "Could not parse ID")
 
 	amount, err := currency.NewFromString(parts[4])
-	abortTxOnError(err, "Could not parse amount in transaction")
+	abortParseOnError(err, "Could not parse amount in transaction")
 
 	return setSellAmountCmd{
 		id:     id,
@@ -79,5 +79,8 @@ func (ssa setSellAmountCmd) Execute() {
 		Amount:    ssa.amount,
 		WorkerID:  *workerNum,
 	}
+
+	acct := accountStore[ssa.userID]
+	acct.AddSummaryItem("Finished " + ssa.Name())
 	consoleLog.Notice(" [✔] Finished", ssa.Name())
 }

--- a/commands_setSellTrigger.go
+++ b/commands_setSellTrigger.go
@@ -18,14 +18,14 @@ type setSellTriggerCmd struct {
 
 func parseSetSellTriggerCmd(parts []string) setSellTriggerCmd {
 	if len(parts) != 5 {
-		abortTx("SET_SELL_TRIGGER needs 5 parts")
+		abortParse("SET_SELL_TRIGGER needs 5 parts")
 	}
 
 	id, err := strconv.ParseUint(parts[0], 10, 64)
-	abortTxOnError(err, "Could not parse ID")
+	abortParseOnError(err, "Could not parse ID")
 
 	amount, err := currency.NewFromString(parts[4])
-	abortTxOnError(err, "Could not parse amount in transaction")
+	abortParseOnError(err, "Could not parse amount in transaction")
 
 	return setSellTriggerCmd{
 		id:     id,
@@ -79,5 +79,8 @@ func (sst setSellTriggerCmd) Execute() {
 	autoTx.Trigger = sst.amount
 	autoTxInitChan <- autoTx
 	consoleLog.Debugf("Published aTx %v successfully", autoTx)
+
+	acct := accountStore[sst.userID]
+	acct.AddSummaryItem("Finished " + sst.Name())
 	consoleLog.Notice(" [✔] Finished", sst.Name())
 }

--- a/static/index.html
+++ b/static/index.html
@@ -218,7 +218,7 @@ function Dumplog() {
   }
   else
   {
-    SendPost("DUMPLOG"+localStorage["user"]+","+document.getElementById("dumplogfile").value)
+    SendPost("DUMPLOG,"+localStorage["user"]+","+document.getElementById("dumplogfile").value)
     console.log("User Dump")
   }
 }

--- a/txWorker.go
+++ b/txWorker.go
@@ -47,12 +47,26 @@ func processTxs(unprocessedTxs <-chan string) {
 	cmd.Execute()
 }
 
-func abortTx(msg string) {
+func abortParse(msg string) {
 	panic(msg)
 }
 
-func abortTxOnError(err error, msg string) {
+func abortParseOnError(err error, msg string) {
 	if err != nil {
+		panic(msg)
+	}
+}
+
+func abortTx(userID, msg string) {
+	acct := accountStore[userID]
+	acct.PushEvent(msg)
+	panic(msg)
+}
+
+func abortTxOnError(err error, userID, msg string) {
+	if err != nil {
+		acct := accountStore[userID]
+		acct.PushEvent(msg)
 		panic(msg)
 	}
 }


### PR DESCRIPTION
If a command can't execute because it fails preconditions (e.g. user doesn't have any stock to sell) then the failure message is sent over the socket.

Pretty :shit: implementation, lots of repetition. Crunch-tastic!

#### Bonus!
Sends back some juicy info about buy/sell quantities. Also fixes a small bug with the dumplog request from FE.